### PR TITLE
`Derived` Util

### DIFF
--- a/core/Derived.ts
+++ b/core/Derived.ts
@@ -1,0 +1,7 @@
+import type { AnyType, Type } from "./Type.ts"
+
+export type Derived<
+  T,
+  X extends AnyType[],
+  P extends keyof any = never,
+> = [Type<T, P | X[number]["P"]>][0]

--- a/core/derived/Date.ts
+++ b/core/derived/Date.ts
@@ -8,7 +8,7 @@ const YearMonthDay: Type<{
   year: number
   month: number
   day: number
-}, never> = object({
+}> = object({
   year: number,
   month: ZeroBasedInteger.assert(asserts.number.max, 11),
   day: number.assert(asserts.number.min, 1).assert(asserts.number.max, 31),
@@ -23,7 +23,7 @@ const YearMonthDay: Type<{
   })
 
 export { Date_ as Date }
-const Date_: Type<Date, never> = transform(
+const Date_: Type<Date> = transform(
   "Date",
   object({
     yearMonthDay: YearMonthDay,

--- a/core/derived/Record.ts
+++ b/core/derived/Record.ts
@@ -1,9 +1,10 @@
-import type { Type } from "../Type.ts"
+import type { Derived } from "../Derived.ts"
+import type { AnyType } from "../Type.ts"
 import { array, string, transform } from "../types.ts"
 import { Tuple } from "./Tuple.ts"
 
-export function Record<T, P extends keyof any>(
-  value: Type<T, P>,
-): Type<Record<string, T>, P> {
+export function Record<V extends AnyType>(
+  value: V,
+): Derived<Record<string, V["T"]>, [V]> {
   return transform("Record", array(Tuple(string, value)), Object.fromEntries)
 }

--- a/core/derived/Tuple.ts
+++ b/core/derived/Tuple.ts
@@ -1,10 +1,10 @@
-import type { AnyType, Type } from "../Type.ts"
+import type { Derived } from "../Derived.ts"
+import type { AnyType } from "../Type.ts"
 import { object, transform } from "../types.ts"
 
-export function Tuple<E extends Array<AnyType>>(...elements: E): Type<
-  { [K in keyof E]: E[K]["T"] },
-  E[number]["P"]
-> {
+export function Tuple<E extends Array<AnyType>>(
+  ...elements: E
+): Derived<{ [K in keyof E]: E[K]["T"] }, E> {
   const { length } = elements
   return transform(
     "Tuple",

--- a/core/derived/Union.ts
+++ b/core/derived/Union.ts
@@ -1,9 +1,10 @@
-import type { AnyType, Type } from "../Type.ts"
+import type { Derived } from "../Derived.ts"
+import type { AnyType } from "../Type.ts"
 import { taggedUnion, transform } from "../types.ts"
 
 export function Union<M extends Array<AnyType>>(
   ...members: M
-): Type<M[number]["T"], M[number]["P"]> {
+): Derived<M[number]["T"], M> {
   return transform(
     "Union",
     taggedUnion("type", Object.fromEntries(members.map((member, i) => [i, member]))),

--- a/core/mod.ts
+++ b/core/mod.ts
@@ -4,6 +4,7 @@ export * from "./TypeVisitor.ts"
 // moderate --exclude derived described.ts types.ts T.ts TypeVisitor.ts
 
 export * from "./Context.ts"
+export * from "./Derived.ts"
 export * from "./deserialize.ts"
 export * from "./Diagnostic.ts"
 export * from "./display.ts"

--- a/docs/NOTES.md
+++ b/docs/NOTES.md
@@ -11,3 +11,4 @@
 - asking for types
 - hydrating types
 - display
+- Derived


### PR DESCRIPTION
For simpler explicit return signatures on pattern libs.

`Tuple` is an example.

```ts
import type { Derived } from "../Derived.ts"
import type { AnyType } from "../Type.ts"
import { object, transform } from "../types.ts"

export function Tuple<E extends Array<AnyType>>(
  ...elements: E
): Derived<{ [K in keyof E]: E[K]["T"] }, E> {
  const { length } = elements
  return transform(
    "Tuple",
    object(Object.fromEntries(Array.from({ length }, (_0, i) => [i, elements[i]!]))),
    (o) => Array.from({ length }, (_0, i) => o[i]),
  ) as never
}


```